### PR TITLE
Add user agent to workaround screen scraping protection

### DIFF
--- a/src/BomClient.php
+++ b/src/BomClient.php
@@ -66,7 +66,10 @@ class BomClient {
     $this->logger = $logger;
     if ($httpClient == NULL) {
       $httpClient = new Client([
-        'headers' => ['Accept-Encoding' => 'gzip'],
+        'headers' => [
+          'Accept-Encoding' => 'gzip', 
+          'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:88.0) Gecko/20100101 Firefox/88.0',
+        ],
       ]);
     }
     $this->httpClient = $httpClient;


### PR DESCRIPTION
BoM recently added some screen scraping protection however XML/JSON feeds appear to have been accidentally caught up in their new web application firewall. As such, this pull request adds support for a default User-Agent to be applied which has been tested as a successful workaround.

Please see https://forums.whirlpool.net.au/thread/3jww2w69 regarding discussion in an online Australian forum for more information.