### PR TITLE
Revise testGetForecast to not make live API calls

### DIFF
--- a/tests/Functional/BomClientTest.php
+++ b/tests/Functional/BomClientTest.php
@@ -3,7 +3,12 @@
 namespace BomWeather\Tests\Functional\Forecast;
 
 use BomWeather\BomClient;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
 /**
@@ -15,13 +20,42 @@ class BomClientTest extends TestCase {
    * @covers ::__construct()
    * @covers ::getForecast()
    */
-  public function testGetForecast() {
+  public function testGetForecast()
+  {
+      $productId = 'IDN10064';
+      $logger = $this->createMock(LoggerInterface::class);
+      $logger
+          ->expects($this->never())
+          ->method('error');
 
-    $logger = new NullLogger();
-    $client = new BomClient($logger);
-    $forecast = $client->getForecast('IDN10064');
+      $responseBody = file_get_contents(__DIR__ . "/../../tests/fixtures/IDN10064.xml");
 
-    $this->assertNotNull($forecast);
+      $mock = new MockHandler([
+          new Response(
+              200,
+              [
+                  'Accept-Ranges' => 'bytes',
+                  'Connection' => 'keep-alive',
+                  'Content-Encoding' => 'gzip',
+                  'Content-Length' => '2010',
+                  'Content-Type' => 'text/xml',
+                  'Date' => 'Wed, 20 Jun 2018 21:41:57 +0000',
+                  'ETag' => '"42b788-49a7-60e2c007ff680"',
+                  'Last-Modified' => 'Wed, 20 Jun 2018 21:41:57 +0000',
+                  'Server' => 'Apache',
+                  'Server-Timing' => 'cdn-cache; desc=REVALIDATE, edge; dur=46, origin; dur=8, ak_p; desc="1704436748525_388610445_1812004694_5393_6883_16_0_-";dur=1',
+                  'Vary' => 'Accept-Encoding',
+              ],
+              $responseBody
+          )
+      ]);
+
+      $handlerStack = HandlerStack::create($mock);
+      $httpClient = new Client(['handler' => $handlerStack]);
+      $client = new BomClient($logger, $httpClient);
+      $forecast = $client->getForecast($productId);
+
+      $this->assertNotNull($forecast);
   }
 
   /**


### PR DESCRIPTION
While attempting to run the tests, `testGetForecast()` consistently failed, with the exception's error message saying that the BOM API had detected the use of automation software during the request. Given that, and that it may well not be necessary to actually make a live request, this change updates the test to use a mock response with one of the fixture files instead. It also improves the performance of the test.