### PR TITLE
Add weather warning support with hazard parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,31 @@ foreach ($locations as $location) {
 
 ```
 
+### Warnings
+
+```php
+$httpClient = new GuzzleHttp\Client(['base_uri' => 'http://www.bom.gov.au/']);
+$requestFactory = new Http\Factory\Guzzle\RequestFactory();
+$client = new BomClient($httpClient, $requestFactory, new NullLogger());
+$warning = $client->getWarning('IDN20400');
+
+$issueTime = $warning->getIssueTime();
+
+// Warning info contains the title and advice.
+$warningInfo = $warning->getWarningInfo();
+$title = $warningInfo->getWarningTitle();
+$nextIssue = $warningInfo->getWarningNextIssue();
+
+// Areas affected by the warning.
+$regions = $warning->getRegions();
+$coasts = $warning->getCoasts();
+
+foreach ($regions as $region) {
+  $aac = $region->getAac();
+  $description = $region->getDescription();
+}
+```
+
 ### Observations
 
 ```php

--- a/src/BomClient.php
+++ b/src/BomClient.php
@@ -8,6 +8,8 @@ use BomWeather\Forecast\Forecast;
 use BomWeather\Forecast\Serializer\ForecastSerializerFactory;
 use BomWeather\Observation\ObservationList;
 use BomWeather\Observation\Serializer\ObservationSerializerFactory;
+use BomWeather\Warning\Serializer\WarningSerializerFactory;
+use BomWeather\Warning\Warning;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
@@ -28,6 +30,7 @@ class BomClient {
     protected LoggerInterface $logger,
     protected ?SerializerInterface $forecastSerializer = NULL,
     protected ?SerializerInterface $observationSerializer = NULL,
+    protected ?SerializerInterface $warningSerializer = NULL,
   ) {
     if ($forecastSerializer == NULL) {
       $forecastSerializer = ForecastSerializerFactory::create();
@@ -38,6 +41,11 @@ class BomClient {
       $observationSerializer = ObservationSerializerFactory::create();
     }
     $this->observationSerializer = $observationSerializer;
+
+    if ($warningSerializer == NULL) {
+      $warningSerializer = WarningSerializerFactory::create();
+    }
+    $this->warningSerializer = $warningSerializer;
   }
 
   /**
@@ -90,6 +98,33 @@ class BomClient {
     }
     catch (ClientExceptionInterface $e) {
       $this->logger->error("Failed to fetch observation list for product $productId and WMO $wmo", [
+        'exception' => $e,
+      ]);
+      return NULL;
+    }
+  }
+
+  /**
+   * Gets a warning.
+   *
+   * @param string $productId
+   *   The product ID. e.g IDN20400.
+   *
+   * @return \BomWeather\Warning\Warning|null
+   *   The warning, or NULL if not found.
+   */
+  public function getWarning(string $productId): ?Warning {
+    try {
+      $request = $this->requestFactory->createRequest('GET', "fwo/$productId.xml")
+        ->withHeader('Accept-Encoding', 'gzip');
+      $response = $this->httpClient->sendRequest($request);
+
+      /** @var \BomWeather\Warning\Warning $warning */
+      $warning = $this->warningSerializer->deserialize($response->getBody(), Warning::class, 'xml');
+      return $warning;
+    }
+    catch (ClientExceptionInterface $e) {
+      $this->logger->error("Failed to fetch warning for ID $productId", [
         'exception' => $e,
       ]);
       return NULL;

--- a/src/Forecast/ForecastPeriod.php
+++ b/src/Forecast/ForecastPeriod.php
@@ -216,7 +216,7 @@ final class ForecastPeriod {
   /**
    * Sets the forecast.
    */
-  public function setForecast(string $forecast): ForecastPeriod {
+  public function setForecast(?string $forecast): ForecastPeriod {
     $this->forecast = $forecast;
     return $this;
   }

--- a/src/Forecast/ForecastPeriod.php
+++ b/src/Forecast/ForecastPeriod.php
@@ -85,6 +85,11 @@ final class ForecastPeriod {
   protected ?string $winds = NULL;
 
   /**
+   * The fire danger value.
+   */
+  protected ?string $fireDanger = NULL;
+
+  /**
    * Gets the start time.
    */
   public function getStartTime(): ?\DateTimeImmutable {
@@ -308,6 +313,21 @@ final class ForecastPeriod {
    */
   public function setWinds(string $winds): ForecastPeriod {
     $this->winds = $winds;
+    return $this;
+  }
+
+  /**
+   * Gets the fire danger value.
+   */
+  public function getFireDanger(): ?string {
+    return $this->fireDanger;
+  }
+
+  /**
+   * Sets the fire danger value.
+   */
+  public function setFireDanger(?string $fireDanger): ForecastPeriod {
+    $this->fireDanger = $fireDanger;
     return $this;
   }
 

--- a/src/Forecast/Serializer/ForecastPeriodNormalizer.php
+++ b/src/Forecast/Serializer/ForecastPeriodNormalizer.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace BomWeather\Forecast\Serializer;
 
 use BomWeather\Forecast\ForecastPeriod;
+use BomWeather\Trait\WeatherDataAccessorTrait;
 use BomWeather\Util\BaseNormalizer;
 
 /**
  * Location period normalizer.
  */
 class ForecastPeriodNormalizer extends BaseNormalizer {
+
+  use WeatherDataAccessorTrait;
 
   /**
    * The supported interface or class.
@@ -71,24 +74,14 @@ class ForecastPeriodNormalizer extends BaseNormalizer {
    *   The period.
    */
   protected function setElementValue(array $element, ForecastPeriod $period): void {
-    switch ($element['@type']) {
-      case 'forecast_icon_code':
-        $period->setIconCode($element['#']);
-        break;
-
-      case 'air_temperature_minimum':
-        $period->setAirTempMinimum((int) $element['#']);
-        break;
-
-      case 'air_temperature_maximum':
-        $period->setAirTempMaximum((int) $element['#']);
-        break;
-
-      case 'precipitation_range':
-        $period->setPrecipitationRange($element['#']);
-        break;
-
-    }
+    $value = $this->accessWeatherData($element, '#');
+    match ($element['@type']) {
+      'forecast_icon_code' => $period->setIconCode($value),
+      'air_temperature_minimum' => $period->setAirTempMinimum((int) $value),
+      'air_temperature_maximum' => $period->setAirTempMaximum((int) $value),
+      'precipitation_range' => $period->setPrecipitationRange($value),
+      default => '',
+    };
   }
 
   /**
@@ -100,40 +93,19 @@ class ForecastPeriodNormalizer extends BaseNormalizer {
    *   The period.
    */
   public function setTextValue(array $text, ForecastPeriod $period): void {
-    switch ($text['@type']) {
-      case 'precis':
-        $period->setPrecis($text['#']);
-        break;
-
-      case 'probability_of_precipitation':
-        $period->setProbabilityOfPrecipitation($text['#']);
-        break;
-
-      case 'forecast':
-        $period->setForecast($text['#']);
-        break;
-
-      case 'uv_alert':
-        $period->setUvAlert($text['#']);
-        break;
-
-      case 'forecast_seas':
-        $period->setSeas($text['#']);
-        break;
-
-      case 'forecast_swell1':
-        $period->setSwell($text['#']);
-        break;
-
-      case 'forecast_weather':
-        $period->setWeather($text['#']);
-        break;
-
-      case 'forecast_winds':
-        $period->setWinds($text['#']);
-        break;
-
-    }
+    $value = $this->accessWeatherData($text, '#');
+    match ($text['@type']) {
+      'precis' => $period->setPrecis($value),
+      'probability_of_precipitation' => $period->setProbabilityOfPrecipitation($value),
+      'forecast' => $period->setForecast($value),
+      'uv_alert' => $period->setUvAlert($value),
+      'forecast_seas' => $period->setSeas($value),
+      'forecast_swell1' => $period->setSwell($value),
+      'forecast_weather' => $period->setWeather($value),
+      'forecast_winds' => $period->setWinds($value),
+      'fire_danger' => $period->setFireDanger($value),
+      default => '',
+    };
   }
 
 }

--- a/src/Trait/WeatherDataAccessorTrait.php
+++ b/src/Trait/WeatherDataAccessorTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BomWeather\Trait;
+
+/**
+ * Trait to provide general data validation and access methods.
+ */
+trait WeatherDataAccessorTrait {
+
+  /**
+   * Access the weather data attribute from weather data array.
+   *
+   * @param array|null $weatherData
+   *   Array of weather data.
+   * @param string $key
+   *   Array key to fetch the data.
+   */
+  public function accessWeatherData(?array $weatherData, string $key): mixed {
+    if (!$weatherData) {
+      return NULL;
+    }
+    if (!\array_key_exists($key, $weatherData)) {
+      return '';
+    }
+    return $weatherData[$key] ?? '';
+  }
+
+}

--- a/src/Trait/WeatherDataAccessorTrait.php
+++ b/src/Trait/WeatherDataAccessorTrait.php
@@ -12,7 +12,7 @@ trait WeatherDataAccessorTrait {
   /**
    * Access the weather data attribute from weather data array.
    *
-   * @param array|null $weatherData
+   * @param array<string, mixed>|null $weatherData
    *   Array of weather data.
    * @param string $key
    *   Array key to fetch the data.

--- a/src/Trait/WeatherDataAccessorTrait.php
+++ b/src/Trait/WeatherDataAccessorTrait.php
@@ -27,4 +27,49 @@ trait WeatherDataAccessorTrait {
     return $weatherData[$key] ?? '';
   }
 
+  /**
+   * Extracts text content, joining nested <p> tags with newlines.
+   *
+   * Handles structures like:
+   * - Simple string: "text"
+   * - Array with '#' key: ['#' => 'text']
+   * - Array with 'p' key containing array: ['p' => ['line1', 'line2']]
+   * - Array with 'p' key containing string: ['p' => 'text']
+   *
+   * @param mixed $data
+   *   The data to extract text from.
+   *
+   * @return string|null
+   *   The extracted text, or NULL if empty.
+   */
+  public function extractTextContent(mixed $data): ?string {
+    if (\is_string($data)) {
+      return $data;
+    }
+
+    if (!\is_array($data)) {
+      return NULL;
+    }
+
+    // Check for direct '#' value.
+    if (isset($data['#'])) {
+      return \is_string($data['#']) ? $data['#'] : NULL;
+    }
+
+    // Check for 'p' tags (nested paragraphs).
+    if (isset($data['p'])) {
+      $paragraphs = $data['p'];
+      if (\is_string($paragraphs)) {
+        return $paragraphs;
+      }
+      if (\is_array($paragraphs)) {
+        // Filter to only strings and join with newlines.
+        $strings = \array_filter($paragraphs, 'is_string');
+        return \implode("\n", $strings) ?: NULL;
+      }
+    }
+
+    return NULL;
+  }
+
 }

--- a/src/Warning/Hazard.php
+++ b/src/Warning/Hazard.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BomWeather\Warning;
+
+use BomWeather\Forecast\Area;
+
+/**
+ * A value object for weather hazard.
+ */
+final class Hazard {
+
+  /**
+   * The hazard type code.
+   */
+  protected ?string $type = NULL;
+
+  /**
+   * The hazard severity.
+   */
+  protected ?HazardSeverity $severity = NULL;
+
+  /**
+   * The hazard urgency.
+   */
+  protected ?HazardUrgency $urgency = NULL;
+
+  /**
+   * The hazard certainty.
+   */
+  protected ?HazardCertainty $certainty = NULL;
+
+  /**
+   * The hazard priority.
+   */
+  protected ?string $priority = NULL;
+
+  /**
+   * The warning phenomena text.
+   */
+  protected ?string $phenomena = NULL;
+
+  /**
+   * The warning areas text.
+   */
+  protected ?string $areas = NULL;
+
+  /**
+   * The affected areas.
+   *
+   * @var \BomWeather\Forecast\Area[]
+   */
+  protected array $affectedAreas = [];
+
+  /**
+   * Gets the hazard type code.
+   */
+  public function getType(): ?string {
+    return $this->type;
+  }
+
+  /**
+   * Sets the hazard type code.
+   */
+  public function setType(?string $type): Hazard {
+    $this->type = $type;
+    return $this;
+  }
+
+  /**
+   * Gets the severity.
+   */
+  public function getSeverity(): ?HazardSeverity {
+    return $this->severity;
+  }
+
+  /**
+   * Sets the severity.
+   */
+  public function setSeverity(?HazardSeverity $severity): Hazard {
+    $this->severity = $severity;
+    return $this;
+  }
+
+  /**
+   * Gets the urgency.
+   */
+  public function getUrgency(): ?HazardUrgency {
+    return $this->urgency;
+  }
+
+  /**
+   * Sets the urgency.
+   */
+  public function setUrgency(?HazardUrgency $urgency): Hazard {
+    $this->urgency = $urgency;
+    return $this;
+  }
+
+  /**
+   * Gets the certainty.
+   */
+  public function getCertainty(): ?HazardCertainty {
+    return $this->certainty;
+  }
+
+  /**
+   * Sets the certainty.
+   */
+  public function setCertainty(?HazardCertainty $certainty): Hazard {
+    $this->certainty = $certainty;
+    return $this;
+  }
+
+  /**
+   * Gets the priority.
+   */
+  public function getPriority(): ?string {
+    return $this->priority;
+  }
+
+  /**
+   * Sets the priority.
+   */
+  public function setPriority(?string $priority): Hazard {
+    $this->priority = $priority;
+    return $this;
+  }
+
+  /**
+   * Gets the phenomena text.
+   */
+  public function getPhenomena(): ?string {
+    return $this->phenomena;
+  }
+
+  /**
+   * Sets the phenomena text.
+   */
+  public function setPhenomena(?string $phenomena): Hazard {
+    $this->phenomena = $phenomena;
+    return $this;
+  }
+
+  /**
+   * Gets the areas text.
+   */
+  public function getAreas(): ?string {
+    return $this->areas;
+  }
+
+  /**
+   * Sets the areas text.
+   */
+  public function setAreas(?string $areas): Hazard {
+    $this->areas = $areas;
+    return $this;
+  }
+
+  /**
+   * Gets the affected areas.
+   *
+   * @return \BomWeather\Forecast\Area[]
+   *   The affected areas.
+   */
+  public function getAffectedAreas(): array {
+    return $this->affectedAreas;
+  }
+
+  /**
+   * Sets the affected areas.
+   *
+   * @param \BomWeather\Forecast\Area[] $affectedAreas
+   *   The affected areas.
+   */
+  public function setAffectedAreas(array $affectedAreas): Hazard {
+    $this->affectedAreas = $affectedAreas;
+    return $this;
+  }
+
+  /**
+   * Adds an affected area.
+   */
+  public function addAffectedArea(Area $area): Hazard {
+    $this->affectedAreas[] = $area;
+    return $this;
+  }
+
+}

--- a/src/Warning/HazardCertainty.php
+++ b/src/Warning/HazardCertainty.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BomWeather\Warning;
+
+/**
+ * Hazard certainty levels.
+ */
+enum HazardCertainty: string {
+
+  case Observed = 'OBS';
+  case Likely = 'LIK';
+  case Possible = 'POS';
+  case Unlikely = 'UNL';
+  case Unknown = 'UNK';
+
+}

--- a/src/Warning/HazardSeverity.php
+++ b/src/Warning/HazardSeverity.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BomWeather\Warning;
+
+/**
+ * Hazard severity levels.
+ */
+enum HazardSeverity: string {
+
+  case Extreme = 'EXT';
+  case Severe = 'SEV';
+  case Strong = 'STR';
+  case Moderate = 'MOD';
+  case Minor = 'MIN';
+  case Unknown = 'UNK';
+
+}

--- a/src/Warning/HazardUrgency.php
+++ b/src/Warning/HazardUrgency.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BomWeather\Warning;
+
+/**
+ * Hazard urgency levels.
+ */
+enum HazardUrgency: string {
+
+  case Immediate = 'IMM';
+  case Expected = 'EXP';
+  case Future = 'FUT';
+  case Past = 'PST';
+  case Unknown = 'UNK';
+
+}

--- a/src/Warning/Serializer/HazardNormalizer.php
+++ b/src/Warning/Serializer/HazardNormalizer.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BomWeather\Warning\Serializer;
+
+use BomWeather\Forecast\Area;
+use BomWeather\Util\BaseNormalizer;
+use BomWeather\Warning\Hazard;
+use BomWeather\Warning\HazardCertainty;
+use BomWeather\Warning\HazardSeverity;
+use BomWeather\Warning\HazardUrgency;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+/**
+ * Hazard normalizer.
+ */
+class HazardNormalizer extends BaseNormalizer {
+
+  /**
+   * The supported interface or class.
+   *
+   * @var string|array<string>
+   */
+  protected string|array $supportedInterfaceOrClass = Hazard::class;
+
+  /**
+   * {@inheritdoc}
+   *
+   * @param mixed $data
+   *   Data to restore.
+   * @param string $type
+   *   The expected class to instantiate.
+   * @param string|null $format
+   *   Format the given data was extracted from.
+   * @param array<string, mixed> $context
+   *   Context options for the denormalizer.
+   */
+  public function denormalize(mixed $data, string $type, ?string $format = NULL, array $context = []): mixed {
+    if (!$this->serializer instanceof DenormalizerInterface) {
+      throw new \RuntimeException('The serializer must implement the DenormalizerInterface.');
+    }
+
+    $hazard = new Hazard();
+
+    // Parse attributes.
+    if (isset($data['@type'])) {
+      $hazard->setType($data['@type']);
+    }
+    if (isset($data['@severity'])) {
+      $hazard->setSeverity(HazardSeverity::tryFrom($data['@severity']) ?? HazardSeverity::Unknown);
+    }
+    if (isset($data['@urgency'])) {
+      $hazard->setUrgency(HazardUrgency::tryFrom($data['@urgency']) ?? HazardUrgency::Unknown);
+    }
+    if (isset($data['@certainty'])) {
+      $hazard->setCertainty(HazardCertainty::tryFrom($data['@certainty']) ?? HazardCertainty::Unknown);
+    }
+
+    // Parse priority.
+    if (isset($data['priority'])) {
+      $hazard->setPriority($data['priority']);
+    }
+
+    // Parse area-list.
+    if (isset($data['area-list']['area'])) {
+      $areas = $data['area-list']['area'];
+      if ($this->isAssoc($areas)) {
+        $hazard->addAffectedArea($this->serializer->denormalize($areas, Area::class));
+      }
+      else {
+        foreach ($areas as $area) {
+          $hazard->addAffectedArea($this->serializer->denormalize($area, Area::class));
+        }
+      }
+    }
+
+    // Parse text elements.
+    if (isset($data['text'])) {
+      $texts = $data['text'];
+      if ($this->isAssoc($texts)) {
+        $this->setTextValue($texts, $hazard);
+      }
+      else {
+        foreach ($texts as $text) {
+          $this->setTextValue($text, $hazard);
+        }
+      }
+    }
+
+    return $hazard;
+  }
+
+  /**
+   * Sets a text value on the hazard.
+   *
+   * @param array<string, mixed> $text
+   *   The text array.
+   * @param \BomWeather\Warning\Hazard $hazard
+   *   The hazard.
+   */
+  protected function setTextValue(array $text, Hazard $hazard): void {
+    $value = $text['#'] ?? NULL;
+    if ($value === NULL) {
+      return;
+    }
+
+    match ($text['@type'] ?? NULL) {
+      'warning_phenomena' => $hazard->setPhenomena($value),
+      'warning_areas' => $hazard->setAreas($value),
+      default => NULL,
+    };
+  }
+
+}

--- a/src/Warning/Serializer/WarningInfoNormalizer.php
+++ b/src/Warning/Serializer/WarningInfoNormalizer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BomWeather\Warning\Serializer;
 
+use BomWeather\Trait\WeatherDataAccessorTrait;
 use BomWeather\Util\BaseNormalizer;
 use BomWeather\Warning\WarningInfo;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -12,6 +13,8 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
  * Forecast normalizer.
  */
 class WarningInfoNormalizer extends BaseNormalizer {
+
+  use WeatherDataAccessorTrait;
 
   /**
    * {@inheritdoc}
@@ -52,13 +55,14 @@ class WarningInfoNormalizer extends BaseNormalizer {
    *   The warning info.
    */
   public function setTextValue(array $text, WarningInfo $warningInfo): void {
+    $value = $this->accessWeatherData($text, '#');
     match ($text['@type']) {
-      'warning_title' => $warningInfo->setWarningTitle($text['#']),
-      'preamble' => $warningInfo->setPreamble($text['#']),
+      'warning_title' => $warningInfo->setWarningTitle($value),
+      'preamble' => $warningInfo->setPreamble($value),
       'warning_advice' => \array_map(function ($advice) use ($warningInfo): void {
         $warningInfo->setWarningAdvice($advice);
-      }, $text['p']),
-      'warning_next_issue' => $warningInfo->setWarningNextIssue($text['#']),
+      }, $this->accessWeatherData($text, 'p')),
+      'warning_next_issue' => $warningInfo->setWarningNextIssue($value),
       default => '',
     };
   }

--- a/src/Warning/Serializer/WarningInfoNormalizer.php
+++ b/src/Warning/Serializer/WarningInfoNormalizer.php
@@ -55,7 +55,7 @@ class WarningInfoNormalizer extends BaseNormalizer {
    *   The warning info.
    */
   public function setTextValue(array $text, WarningInfo $warningInfo): void {
-    $value = $this->accessWeatherData($text, '#');
+    $value = array_key_exists('#', $text) ? $this->accessWeatherData($text, '#') : $this->accessWeatherData($text, 'p');
     match ($text['@type']) {
       'warning_title' => $warningInfo->setWarningTitle($value),
       'preamble' => $warningInfo->setPreamble($value),

--- a/src/Warning/Serializer/WarningInfoNormalizer.php
+++ b/src/Warning/Serializer/WarningInfoNormalizer.php
@@ -55,7 +55,7 @@ class WarningInfoNormalizer extends BaseNormalizer {
    *   The warning info.
    */
   public function setTextValue(array $text, WarningInfo $warningInfo): void {
-    $value = array_key_exists('#', $text) ? $this->accessWeatherData($text, '#') : $this->accessWeatherData($text, 'p');
+    $value = \array_key_exists('#', $text) ? $this->accessWeatherData($text, '#') : $this->accessWeatherData($text, 'p');
     match ($text['@type']) {
       'warning_title' => $warningInfo->setWarningTitle($value),
       'preamble' => $warningInfo->setPreamble($value),

--- a/src/Warning/Serializer/WarningInfoNormalizer.php
+++ b/src/Warning/Serializer/WarningInfoNormalizer.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BomWeather\Warning\Serializer;
+
+use BomWeather\Forecast\Area;
+use BomWeather\Forecast\Forecast;
+use BomWeather\Util\BaseNormalizer;
+use BomWeather\Warning\Warning;
+use BomWeather\Warning\WarningInfo;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+/**
+ * Forecast normalizer.
+ */
+class WarningInfoNormalizer extends BaseNormalizer {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected string|array $supportedInterfaceOrClass = WarningInfo::class;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function denormalize($data, $type, $format = NULL, array $context = []) {
+    if (!$this->serializer instanceof DenormalizerInterface) {
+      throw new \RuntimeException('The serializer must implement the DenormalizerInterface.');
+    }
+
+    $warningInfo = (new WarningInfo());
+
+
+    return $warningInfo;
+  }
+
+}

--- a/src/Warning/Serializer/WarningInfoNormalizer.php
+++ b/src/Warning/Serializer/WarningInfoNormalizer.php
@@ -59,9 +59,9 @@ class WarningInfoNormalizer extends BaseNormalizer {
     match ($text['@type']) {
       'warning_title' => $warningInfo->setWarningTitle($value),
       'preamble' => $warningInfo->setPreamble($value),
-      'warning_advice' => \array_map(function ($advice) use ($warningInfo): void {
+      'warning_advice' => \is_array($value) ? \array_map(function ($advice) use ($warningInfo): void {
         $warningInfo->setWarningAdvice($advice);
-      }, $this->accessWeatherData($text, 'p')),
+      }, $value) : $warningInfo->setWarningAdvice($value),
       'warning_next_issue' => $warningInfo->setWarningNextIssue($value),
       default => '',
     };

--- a/src/Warning/Serializer/WarningInfoNormalizer.php
+++ b/src/Warning/Serializer/WarningInfoNormalizer.php
@@ -61,15 +61,39 @@ class WarningInfoNormalizer extends BaseNormalizer {
    *   The warning info.
    */
   public function setTextValue(array $text, WarningInfo $warningInfo): void {
-    $value = \array_key_exists('#', $text) ? $this->accessWeatherData($text, '#') : $this->accessWeatherData($text, 'p');
-    match ($text['@type']) {
+    // Extract text content, handling nested <p> tags.
+    $value = $this->extractTextContent($text);
+
+    // Handle warning_advice specially as it can be an array.
+    if (($text['@type'] ?? NULL) === 'warning_advice') {
+      if (\is_array($text['p'] ?? NULL)) {
+        foreach ($text['p'] as $advice) {
+          if (\is_string($advice)) {
+            $warningInfo->setWarningAdvice($advice);
+          }
+        }
+      }
+      elseif ($value !== NULL) {
+        $warningInfo->setWarningAdvice($value);
+      }
+      return;
+    }
+
+    if ($value === NULL) {
+      return;
+    }
+
+    match ($text['@type'] ?? NULL) {
       'warning_title' => $warningInfo->setWarningTitle($value),
       'preamble' => $warningInfo->setPreamble($value),
-      'warning_advice' => \is_array($value) ? \array_map(static function ($advice) use ($warningInfo): void {
-        $warningInfo->setWarningAdvice($advice);
-      }, $value) : $warningInfo->setWarningAdvice($value),
       'warning_next_issue' => $warningInfo->setWarningNextIssue($value),
-      default => '',
+      'postamble' => $warningInfo->setPostamble($value),
+      'warning_area_summary' => $warningInfo->setAreaSummary($value),
+      'warning_phenomena_summary' => $warningInfo->setPhenomenaSummary($value),
+      'warning_headline' => $warningInfo->setHeadline($value),
+      'synoptic_situation' => $warningInfo->setSynopticSituation($value),
+      'warning_advice_contact' => $warningInfo->setWarningAdvice($value),
+      default => NULL,
     };
   }
 

--- a/src/Warning/Serializer/WarningInfoNormalizer.php
+++ b/src/Warning/Serializer/WarningInfoNormalizer.php
@@ -16,9 +16,6 @@ class WarningInfoNormalizer extends BaseNormalizer {
 
   use WeatherDataAccessorTrait;
 
-  /**
-   * {@inheritdoc}
-   */
   protected string|array $supportedInterfaceOrClass = WarningInfo::class;
 
   /**
@@ -68,7 +65,7 @@ class WarningInfoNormalizer extends BaseNormalizer {
     match ($text['@type']) {
       'warning_title' => $warningInfo->setWarningTitle($value),
       'preamble' => $warningInfo->setPreamble($value),
-      'warning_advice' => \is_array($value) ? \array_map(function ($advice) use ($warningInfo): void {
+      'warning_advice' => \is_array($value) ? \array_map(static function ($advice) use ($warningInfo): void {
         $warningInfo->setWarningAdvice($advice);
       }, $value) : $warningInfo->setWarningAdvice($value),
       'warning_next_issue' => $warningInfo->setWarningNextIssue($value),

--- a/src/Warning/Serializer/WarningInfoNormalizer.php
+++ b/src/Warning/Serializer/WarningInfoNormalizer.php
@@ -23,8 +23,17 @@ class WarningInfoNormalizer extends BaseNormalizer {
 
   /**
    * {@inheritdoc}
+   *
+   * @param mixed $data
+   *   Data to restore.
+   * @param string $type
+   *   The expected class to instantiate.
+   * @param string|null $format
+   *   Format the given data was extracted from.
+   * @param array<string, mixed> $context
+   *   Context options for the denormalizer.
    */
-  public function denormalize($data, $type, $format = NULL, array $context = []) {
+  public function denormalize(mixed $data, string $type, ?string $format = NULL, array $context = []): mixed {
     if (!$this->serializer instanceof DenormalizerInterface) {
       throw new \RuntimeException('The serializer must implement the DenormalizerInterface.');
     }
@@ -49,7 +58,7 @@ class WarningInfoNormalizer extends BaseNormalizer {
   /**
    * Sets a text value.
    *
-   * @param array $text
+   * @param array<string, mixed> $text
    *   The text array.
    * @param \BomWeather\Warning\WarningInfo $warningInfo
    *   The warning info.

--- a/src/Warning/Serializer/WarningNormalizer.php
+++ b/src/Warning/Serializer/WarningNormalizer.php
@@ -31,14 +31,16 @@ class WarningNormalizer extends BaseNormalizer {
     $warning = (new Warning())
       ->setIssueTime($this->serializer->denormalize($data['amoc']['issue-time-utc'], \DateTimeImmutable::class));
 
-    if ($this->isAssoc($data['warning']['area'])) {
-      $area = $data['warning']['area'];
-      $this->setValue($area, $warning);
-    }
-    else {
-      \array_map(function ($area) use ($warning): void {
+    if (array_key_exists('warning', $data)) {
+      if ($this->isAssoc($data['warning']['area'])) {
+        $area = $data['warning']['area'];
         $this->setValue($area, $warning);
-      }, $data['warning']['area'], [$warning]);
+      }
+      else {
+        \array_map(function ($area) use ($warning): void {
+          $this->setValue($area, $warning);
+        }, $data['warning']['area'], [$warning]);
+      }
     }
 
     $warningInfo = $this->serializer->denormalize($data['warning']['warning-info'], WarningInfo::class);

--- a/src/Warning/Serializer/WarningNormalizer.php
+++ b/src/Warning/Serializer/WarningNormalizer.php
@@ -31,7 +31,7 @@ class WarningNormalizer extends BaseNormalizer {
     $warning = (new Warning())
       ->setIssueTime($this->serializer->denormalize($data['amoc']['issue-time-utc'], \DateTimeImmutable::class));
 
-    if (array_key_exists('warning', $data)) {
+    if (\array_key_exists('warning', $data)) {
       if ($this->isAssoc($data['warning']['area'])) {
         $area = $data['warning']['area'];
         $this->setValue($area, $warning);

--- a/src/Warning/Serializer/WarningNormalizer.php
+++ b/src/Warning/Serializer/WarningNormalizer.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace BomWeather\Warning\Serializer;
 
 use BomWeather\Forecast\Area;
-use BomWeather\Forecast\Forecast;
 use BomWeather\Util\BaseNormalizer;
 use BomWeather\Warning\Warning;
 use BomWeather\Warning\WarningInfo;
@@ -43,6 +42,7 @@ class WarningNormalizer extends BaseNormalizer {
     }
 
     $warningInfo = $this->serializer->denormalize($data['warning']['warning-info'], WarningInfo::class);
+    $warning->setWarningInfo($warningInfo);
 
     return $warning;
   }

--- a/src/Warning/Serializer/WarningNormalizer.php
+++ b/src/Warning/Serializer/WarningNormalizer.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BomWeather\Warning\Serializer;
+
+use BomWeather\Forecast\Area;
+use BomWeather\Forecast\Forecast;
+use BomWeather\Util\BaseNormalizer;
+use BomWeather\Warning\Warning;
+use BomWeather\Warning\WarningInfo;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+/**
+ * Forecast normalizer.
+ */
+class WarningNormalizer extends BaseNormalizer {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected string|array $supportedInterfaceOrClass = Warning::class;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function denormalize($data, $type, $format = NULL, array $context = []) {
+    if (!$this->serializer instanceof DenormalizerInterface) {
+      throw new \RuntimeException('The serializer must implement the DenormalizerInterface.');
+    }
+
+    $warning = (new Warning())
+      ->setIssueTime($this->serializer->denormalize($data['amoc']['issue-time-utc'], \DateTimeImmutable::class));
+
+    if ($this->isAssoc($data['warning']['area'])) {
+      $area = $data['warning']['area'];
+      $this->setValue($area, $warning);
+    }
+    else {
+      \array_map(function ($area) use ($warning): void {
+        $this->setValue($area, $warning);
+      }, $data['warning']['area'], [$warning]);
+    }
+
+    $warningInfo = $this->serializer->denormalize($data['warning']['warning-info'], WarningInfo::class);
+
+    return $warning;
+  }
+
+  /**
+   * Sets the area value.
+   *
+   * @param array $area
+   *   The area data.
+   * @param \BomWeather\Warning\Warning $warning
+   *   The warning.
+   */
+  public function setValue(array $area, Warning $warning): void {
+    switch ($area['@type']) {
+      case Area::TYPE_REGION:
+        $warning->addRegion($this->serializer->denormalize($area, Area::class));
+        break;
+
+      case Area::TYPE_DISTRICT:
+        $warning->addDistrict($this->serializer->denormalize($area, Area::class));
+        break;
+
+      case Area::TYPE_METROPOLITAN:
+        $warning->addMetropolitanArea($this->serializer->denormalize($area, Area::class));
+        break;
+
+      case Area::TYPE_LOCATION:
+        $warning->addLocation($this->serializer->denormalize($area, Area::class));
+        break;
+
+      case Area::TYPE_COAST:
+        $warning->addCoast($this->serializer->denormalize($area, Area::class));
+        break;
+    }
+  }
+
+}

--- a/src/Warning/Serializer/WarningNormalizer.php
+++ b/src/Warning/Serializer/WarningNormalizer.php
@@ -41,10 +41,9 @@ class WarningNormalizer extends BaseNormalizer {
           $this->setValue($area, $warning);
         }, $data['warning']['area'], [$warning]);
       }
+      $warningInfo = $this->serializer->denormalize($data['warning']['warning-info'], WarningInfo::class);
+      $warning->setWarningInfo($warningInfo);
     }
-
-    $warningInfo = $this->serializer->denormalize($data['warning']['warning-info'], WarningInfo::class);
-    $warning->setWarningInfo($warningInfo);
 
     return $warning;
   }

--- a/src/Warning/Serializer/WarningNormalizer.php
+++ b/src/Warning/Serializer/WarningNormalizer.php
@@ -22,8 +22,17 @@ class WarningNormalizer extends BaseNormalizer {
 
   /**
    * {@inheritdoc}
+   *
+   * @param mixed $data
+   *   Data to restore.
+   * @param string $type
+   *   The expected class to instantiate.
+   * @param string|null $format
+   *   Format the given data was extracted from.
+   * @param array<string, mixed> $context
+   *   Context options for the denormalizer.
    */
-  public function denormalize($data, $type, $format = NULL, array $context = []) {
+  public function denormalize(mixed $data, string $type, ?string $format = NULL, array $context = []): mixed {
     if (!$this->serializer instanceof DenormalizerInterface) {
       throw new \RuntimeException('The serializer must implement the DenormalizerInterface.');
     }
@@ -51,7 +60,7 @@ class WarningNormalizer extends BaseNormalizer {
   /**
    * Sets the area value.
    *
-   * @param array $area
+   * @param array<string, mixed> $area
    *   The area data.
    * @param \BomWeather\Warning\Warning $warning
    *   The warning.

--- a/src/Warning/Serializer/WarningNormalizer.php
+++ b/src/Warning/Serializer/WarningNormalizer.php
@@ -6,6 +6,7 @@ namespace BomWeather\Warning\Serializer;
 
 use BomWeather\Forecast\Area;
 use BomWeather\Util\BaseNormalizer;
+use BomWeather\Warning\Hazard;
 use BomWeather\Warning\Warning;
 use BomWeather\Warning\WarningInfo;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -83,6 +84,43 @@ class WarningNormalizer extends BaseNormalizer {
       case Area::TYPE_COAST:
         $warning->addCoast($this->serializer->denormalize($area, Area::class));
         break;
+    }
+
+    // Parse hazards from forecast-period elements.
+    $this->parseHazards($area, $warning);
+  }
+
+  /**
+   * Parses hazards from area forecast-period elements.
+   *
+   * @param array<string, mixed> $area
+   *   The area data.
+   * @param \BomWeather\Warning\Warning $warning
+   *   The warning.
+   */
+  protected function parseHazards(array $area, Warning $warning): void {
+    if (!isset($area['forecast-period'])) {
+      return;
+    }
+
+    $periods = $area['forecast-period'];
+    if ($this->isAssoc($periods)) {
+      $periods = [$periods];
+    }
+
+    foreach ($periods as $period) {
+      if (!isset($period['hazard'])) {
+        continue;
+      }
+
+      $hazards = $period['hazard'];
+      if ($this->isAssoc($hazards)) {
+        $hazards = [$hazards];
+      }
+
+      foreach ($hazards as $hazardData) {
+        $warning->addHazard($this->serializer->denormalize($hazardData, Hazard::class));
+      }
     }
   }
 

--- a/src/Warning/Serializer/WarningNormalizer.php
+++ b/src/Warning/Serializer/WarningNormalizer.php
@@ -15,9 +15,6 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
  */
 class WarningNormalizer extends BaseNormalizer {
 
-  /**
-   * {@inheritdoc}
-   */
   protected string|array $supportedInterfaceOrClass = Warning::class;
 
   /**

--- a/src/Warning/Serializer/WarningSerializerFactory.php
+++ b/src/Warning/Serializer/WarningSerializerFactory.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace BomWeather\Warning\Serializer;
 
 use BomWeather\Forecast\Serializer\AreaNormalizer;
-use BomWeather\Forecast\Serializer\ForecastNormalizer;
 use BomWeather\Forecast\Serializer\ForecastPeriodNormalizer;
 use Symfony\Component\Serializer\Encoder\XmlEncoder;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
@@ -32,6 +31,7 @@ class WarningSerializerFactory {
       new WarningNormalizer(),
       new WarningInfoNormalizer(),
       new AreaNormalizer(),
+      new ForecastPeriodNormalizer(),
     ];
     return new Serializer($normalizers, $encoders);
   }

--- a/src/Warning/Serializer/WarningSerializerFactory.php
+++ b/src/Warning/Serializer/WarningSerializerFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BomWeather\Warning\Serializer;
+
+use BomWeather\Forecast\Serializer\AreaNormalizer;
+use BomWeather\Forecast\Serializer\ForecastNormalizer;
+use BomWeather\Forecast\Serializer\ForecastPeriodNormalizer;
+use Symfony\Component\Serializer\Encoder\XmlEncoder;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Serializer\Serializer;
+
+/**
+ * Factory for creating a weather warning data.
+ */
+class WarningSerializerFactory {
+
+  /**
+   * Creates a new forecast serializer.
+   *
+   * @param string $rootNode
+   *   (optional) The root node of the XML.
+   *
+   * @return \Symfony\Component\Serializer\Serializer
+   *   The serializer.
+   */
+  public static function create(string $rootNode = 'product'): Serializer {
+    $encoders = [new XmlEncoder([XmlEncoder::ROOT_NODE_NAME => $rootNode])];
+    $normalizers = [
+      new DateTimeNormalizer([DateTimeNormalizer::TIMEZONE_KEY => 'UTC']),
+      new WarningNormalizer(),
+      new WarningInfoNormalizer(),
+      new AreaNormalizer(),
+    ];
+    return new Serializer($normalizers, $encoders);
+  }
+
+}

--- a/src/Warning/Serializer/WarningSerializerFactory.php
+++ b/src/Warning/Serializer/WarningSerializerFactory.php
@@ -30,6 +30,7 @@ class WarningSerializerFactory {
       new DateTimeNormalizer([DateTimeNormalizer::TIMEZONE_KEY => 'UTC']),
       new WarningNormalizer(),
       new WarningInfoNormalizer(),
+      new HazardNormalizer(),
       new AreaNormalizer(),
       new ForecastPeriodNormalizer(),
     ];

--- a/src/Warning/Warning.php
+++ b/src/Warning/Warning.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BomWeather\Warning;
+
+use BomWeather\Forecast\Area;
+
+/**
+ * A value object for weather forcasts.
+ */
+final class Warning {
+
+  /**
+   * The regions.
+   *
+   * @var \BomWeather\Forecast\Area[]
+   */
+  protected array $regions = [];
+
+  /**
+   * The districts.
+   *
+   * @var \BomWeather\Forecast\Area[]
+   */
+  protected array $districts = [];
+
+  /**
+   * The metropolitan areas.
+   *
+   * @var \BomWeather\Forecast\Area[]
+   */
+  protected array $metropolitanAreas = [];
+
+  /**
+   * The locations.
+   *
+   * @var \BomWeather\Forecast\Area[]
+   */
+  protected array $locations = [];
+
+  /**
+   * The coastal waters.
+   *
+   * @var \BomWeather\Forecast\Area[]
+   */
+  protected array $coasts = [];
+
+  /**
+   * The issue time.
+   */
+  protected \DateTimeImmutable $issueTime;
+
+  /**
+   * Gets the regions.
+   *
+   * @return \BomWeather\Forecast\Area[]
+   *   The regions.
+   */
+  public function getRegions(): array {
+    return $this->regions;
+  }
+
+  /**
+   * Sets the regions.
+   *
+   * @param \BomWeather\Forecast\Area[] $regions
+   *   The regions.
+   *
+   * @return $this
+   */
+  public function setRegions(array $regions): Warning {
+    $this->regions = $regions;
+    return $this;
+  }
+
+  /**
+   * Adds a region.
+   *
+   * @param \BomWeather\Forecast\Area $region
+   *   The region.
+   *
+   * @return $this
+   */
+  public function addRegion(Area $region): Warning {
+    $this->regions[] = $region;
+    return $this;
+  }
+
+  /**
+   * Gets the districts.
+   *
+   * @return \BomWeather\Forecast\Area[]
+   *   The districts.
+   */
+  public function getDistricts(): array {
+    return $this->districts;
+  }
+
+  /**
+   * Sets the districts.
+   *
+   * @param \BomWeather\Forecast\Area[] $districts
+   *   The districts.
+   *
+   * @return $this
+   */
+  public function setDistricts(array $districts): Warning {
+    $this->districts = $districts;
+    return $this;
+  }
+
+  /**
+   * Adds a district.
+   *
+   * @param \BomWeather\Forecast\Area $district
+   *   The district.
+   *
+   * @return $this
+   */
+  public function addDistrict(Area $district): Warning {
+    $this->districts[] = $district;
+    return $this;
+  }
+
+  /**
+   * Gets the metropolitan areas.
+   *
+   * @return \BomWeather\Forecast\Area[]
+   *   The metropolitan areas.
+   */
+  public function getMetropolitanAreas(): array {
+    return $this->metropolitanAreas;
+  }
+
+  /**
+   * Sets the metropolitan areas.
+   *
+   * @param \BomWeather\Forecast\Area[] $metropolitanAreas
+   *   The metropolitan areas.
+   *
+   * @return $this
+   */
+  public function setMetropolitanAreas(array $metropolitanAreas): Warning {
+    $this->metropolitanAreas = $metropolitanAreas;
+    return $this;
+  }
+
+  /**
+   * Adds a metropolitan area.
+   *
+   * @param \BomWeather\Forecast\Area $metropolitanArea
+   *   The metropolitan area.
+   *
+   * @return $this
+   */
+  public function addMetropolitanArea(Area $metropolitanArea): Warning {
+    $this->metropolitanAreas[] = $metropolitanArea;
+    return $this;
+  }
+
+  /**
+   * Gets the locations.
+   *
+   * @return \BomWeather\Forecast\Area[]
+   *   The locations.
+   */
+  public function getLocations(): array {
+    return $this->locations;
+  }
+
+  /**
+   * Sets the locations.
+   *
+   * @param \BomWeather\Forecast\Area[] $locations
+   *   The locations.
+   *
+   * @return $this
+   */
+  public function setLocations(array $locations): Warning {
+    $this->locations = $locations;
+    return $this;
+  }
+
+  /**
+   * Adds a location.
+   *
+   * @param \BomWeather\Forecast\Area $location
+   *   The location.
+   *
+   * @return $this
+   */
+  public function addLocation(Area $location): Warning {
+    $this->locations[] = $location;
+    return $this;
+  }
+
+  /**
+   * Gets the issue time.
+   */
+  public function getIssueTime(): ?\DateTimeImmutable {
+    return $this->issueTime;
+  }
+
+  /**
+   * Sets the issue time.
+   */
+  public function setIssueTime(\DateTimeImmutable $issueTime): Warning {
+    $this->issueTime = $issueTime;
+    return $this;
+  }
+
+  /**
+   * Gets the coasts.
+   *
+   * @return \BomWeather\Forecast\Area[]
+   *   The coasts.
+   */
+  public function getCoasts(): array {
+    return $this->coasts;
+  }
+
+  /**
+   * Sets the coasts.
+   *
+   * @param \BomWeather\Forecast\Area[] $coasts
+   *   The coasts.
+   *
+   * @return $this
+   */
+  public function setCoasts(array $coasts): Warning {
+    $this->coasts = $coasts;
+    return $this;
+  }
+
+  /**
+   * Adds a coast.
+   *
+   * @param \BomWeather\Forecast\Area $coast
+   *   The coast.
+   *
+   * @return $this
+   */
+  public function addCoast(Area $coast): Warning {
+    $this->coasts[] = $coast;
+    return $this;
+  }
+
+}

--- a/src/Warning/Warning.php
+++ b/src/Warning/Warning.php
@@ -7,7 +7,7 @@ namespace BomWeather\Warning;
 use BomWeather\Forecast\Area;
 
 /**
- * A value object for weather forcasts.
+ * A value object for weather warning.
  */
 final class Warning {
 
@@ -50,6 +50,11 @@ final class Warning {
    * The issue time.
    */
   protected \DateTimeImmutable $issueTime;
+
+  /**
+   * The warning information.
+   */
+  protected ?WarningInfo $warningInfo = NULL;
 
   /**
    * Gets the regions.
@@ -243,6 +248,21 @@ final class Warning {
    */
   public function addCoast(Area $coast): Warning {
     $this->coasts[] = $coast;
+    return $this;
+  }
+
+  /**
+   * Gets the warning information.
+   */
+  public function getWarningInfo(): ?WarningInfo {
+    return $this->warningInfo;
+  }
+
+  /**
+   * Sets the warning information.
+   */
+  public function setWarningInfo(?WarningInfo $warningInfo): Warning {
+    $this->warningInfo = $warningInfo;
     return $this;
   }
 

--- a/src/Warning/Warning.php
+++ b/src/Warning/Warning.php
@@ -57,6 +57,13 @@ final class Warning {
   protected ?WarningInfo $warningInfo = NULL;
 
   /**
+   * The hazards.
+   *
+   * @var \BomWeather\Warning\Hazard[]
+   */
+  protected array $hazards = [];
+
+  /**
    * Gets the regions.
    *
    * @return \BomWeather\Forecast\Area[]
@@ -263,6 +270,35 @@ final class Warning {
    */
   public function setWarningInfo(?WarningInfo $warningInfo): Warning {
     $this->warningInfo = $warningInfo;
+    return $this;
+  }
+
+  /**
+   * Gets the hazards.
+   *
+   * @return \BomWeather\Warning\Hazard[]
+   *   The hazards.
+   */
+  public function getHazards(): array {
+    return $this->hazards;
+  }
+
+  /**
+   * Sets the hazards.
+   *
+   * @param \BomWeather\Warning\Hazard[] $hazards
+   *   The hazards.
+   */
+  public function setHazards(array $hazards): Warning {
+    $this->hazards = $hazards;
+    return $this;
+  }
+
+  /**
+   * Adds a hazard.
+   */
+  public function addHazard(Hazard $hazard): Warning {
+    $this->hazards[] = $hazard;
     return $this;
   }
 

--- a/src/Warning/Warning.php
+++ b/src/Warning/Warning.php
@@ -203,7 +203,7 @@ final class Warning {
   /**
    * Gets the issue time.
    */
-  public function getIssueTime(): ?\DateTimeImmutable {
+  public function getIssueTime(): \DateTimeImmutable {
     return $this->issueTime;
   }
 

--- a/src/Warning/WarningInfo.php
+++ b/src/Warning/WarningInfo.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BomWeather\Warning;
+
+use BomWeather\Forecast\Area;
+
+/**
+ * A value object for weather forcasts.
+ */
+final class WarningInfo {
+
+  /**
+   * The warning title.
+   */
+  protected ?string $warningTitle = NULL;
+
+  /**
+   * The warning preamble text.
+   */
+  protected ?string $preamble = NULL;
+
+  /**
+   * The warning advices.
+   */
+  protected array $warningAdvice = [];
+
+  /**
+   * The warning next issue help text.
+   */
+  protected ?string $warningNextIssue = NULL;
+
+  /**
+   * Gets the warning title.
+   */
+  public function getWarningTitle(): ?string {
+    return $this->warningTitle;
+  }
+
+  /**
+   * Sets the warning title.
+   */
+  public function setWarningTitle(?string $warningTitle): WarningInfo {
+    $this->warningTitle = $warningTitle;
+    return $this;
+  }
+
+  /**
+   * Gets the preamble text.
+   */
+  public function getPreamble(): ?string {
+    return $this->preamble;
+  }
+
+  /**
+   * Sets the preamble text.
+   */
+  public function setPreamble(?string $preamble): WarningInfo {
+    $this->preamble = $preamble;
+    return $this;
+  }
+
+  /**
+   * Gets an array of warning advices.
+   */
+  public function getWarningAdvices(): array {
+    return $this->warningAdvice;
+  }
+
+  /**
+   * Sets warning advice to advices array.
+   */
+  public function setWarningAdvice(string $warningAdvice): WarningInfo {
+    $this->warningAdvice[] = $warningAdvice;
+    return $this;
+  }
+
+  /**
+   * Get the text for next warning issue date.
+   */
+  public function getWarningNextIssue(): ?string {
+    return $this->warningNextIssue;
+  }
+
+  /**
+   * Set the text for next warning issue date.
+   */
+  public function setWarningNextIssue(?string $warningNextIssue): WarningInfo {
+    $this->warningNextIssue = $warningNextIssue;
+    return $this;
+  }
+
+}

--- a/src/Warning/WarningInfo.php
+++ b/src/Warning/WarningInfo.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace BomWeather\Warning;
 
-use BomWeather\Forecast\Area;
-
 /**
- * A value object for weather forcasts.
+ * A value object for weather warning information.
  */
 final class WarningInfo {
 

--- a/src/Warning/WarningInfo.php
+++ b/src/Warning/WarningInfo.php
@@ -21,6 +21,8 @@ final class WarningInfo {
 
   /**
    * The warning advices.
+   *
+   * @var string[]
    */
   protected array $warningAdvice = [];
 
@@ -61,6 +63,9 @@ final class WarningInfo {
 
   /**
    * Gets an array of warning advices.
+   *
+   * @return string[]
+   *   The warning advices.
    */
   public function getWarningAdvices(): array {
     return $this->warningAdvice;

--- a/src/Warning/WarningInfo.php
+++ b/src/Warning/WarningInfo.php
@@ -32,6 +32,31 @@ final class WarningInfo {
   protected ?string $warningNextIssue = NULL;
 
   /**
+   * The postamble text.
+   */
+  protected ?string $postamble = NULL;
+
+  /**
+   * The warning area summary.
+   */
+  protected ?string $areaSummary = NULL;
+
+  /**
+   * The warning phenomena summary.
+   */
+  protected ?string $phenomenaSummary = NULL;
+
+  /**
+   * The warning headline.
+   */
+  protected ?string $headline = NULL;
+
+  /**
+   * The synoptic situation.
+   */
+  protected ?string $synopticSituation = NULL;
+
+  /**
    * Gets the warning title.
    */
   public function getWarningTitle(): ?string {
@@ -91,6 +116,81 @@ final class WarningInfo {
    */
   public function setWarningNextIssue(?string $warningNextIssue): WarningInfo {
     $this->warningNextIssue = $warningNextIssue;
+    return $this;
+  }
+
+  /**
+   * Gets the postamble text.
+   */
+  public function getPostamble(): ?string {
+    return $this->postamble;
+  }
+
+  /**
+   * Sets the postamble text.
+   */
+  public function setPostamble(?string $postamble): WarningInfo {
+    $this->postamble = $postamble;
+    return $this;
+  }
+
+  /**
+   * Gets the area summary.
+   */
+  public function getAreaSummary(): ?string {
+    return $this->areaSummary;
+  }
+
+  /**
+   * Sets the area summary.
+   */
+  public function setAreaSummary(?string $areaSummary): WarningInfo {
+    $this->areaSummary = $areaSummary;
+    return $this;
+  }
+
+  /**
+   * Gets the phenomena summary.
+   */
+  public function getPhenomenaSummary(): ?string {
+    return $this->phenomenaSummary;
+  }
+
+  /**
+   * Sets the phenomena summary.
+   */
+  public function setPhenomenaSummary(?string $phenomenaSummary): WarningInfo {
+    $this->phenomenaSummary = $phenomenaSummary;
+    return $this;
+  }
+
+  /**
+   * Gets the headline.
+   */
+  public function getHeadline(): ?string {
+    return $this->headline;
+  }
+
+  /**
+   * Sets the headline.
+   */
+  public function setHeadline(?string $headline): WarningInfo {
+    $this->headline = $headline;
+    return $this;
+  }
+
+  /**
+   * Gets the synoptic situation.
+   */
+  public function getSynopticSituation(): ?string {
+    return $this->synopticSituation;
+  }
+
+  /**
+   * Sets the synoptic situation.
+   */
+  public function setSynopticSituation(?string $synopticSituation): WarningInfo {
+    $this->synopticSituation = $synopticSituation;
     return $this;
   }
 

--- a/tests/fixtures/IDN20400.xml
+++ b/tests/fixtures/IDN20400.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<product version="1.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.bom.gov.au/schema/v1.7/product.xsd">
+    <amoc>
+        <source>
+            <sender>Australian Government Bureau of Meteorology</sender>
+            <region>New South Wales</region>
+            <office>NSWRO</office>
+            <copyright>http://www.bom.gov.au/other/copyright.shtml</copyright>
+            <disclaimer>http://www.bom.gov.au/other/disclaimer.shtml</disclaimer>
+        </source>
+        <identifier>IDN20400</identifier>
+        <issue-time-utc>2026-04-21T00:00:00Z</issue-time-utc>
+        <issue-time-local tz="EST">2026-04-21T10:00:00+10:00</issue-time-local>
+        <sent-time>2026-04-21T00:00:01Z</sent-time>
+        <expiry-time>2026-04-21T14:00:00Z</expiry-time>
+        <validity-bgn-time-local tz="EST">2026-04-21T10:00:00+10:00</validity-bgn-time-local>
+        <validity-end-time-local tz="EST">2026-04-21T23:59:59+10:00</validity-end-time-local>
+        <next-routine-issue-time-utc>2026-04-21T06:05:00Z</next-routine-issue-time-utc>
+        <next-routine-issue-time-local tz="EST">2026-04-21T16:05:00+10:00</next-routine-issue-time-local>
+        <status>O</status>
+        <service>WSM</service>
+        <sub-service>WMS</sub-service>
+        <product-type>W</product-type>
+        <phase>REN</phase>
+    </amoc>
+    <warning>
+        <warning-info>
+            <text type="warning_title">Marine Wind Warning Summary for New South Wales</text>
+            <text type="postamble">Check the latest Coastal Waters Forecast or Local Waters Forecast at http://www.bom.gov.au/nsw/forecasts/map.shtml for information on wind, wave and weather conditions for these coastal zones.</text>
+            <text type="warning_next_issue">The next marine wind warning summary will be issued by 4:05 pm EST Tuesday.</text>
+        </warning-info>
+        <!---->
+        <!--locale[NSW_FA001, allow-output=yes]-->
+        <!--hazards-exist="yes" non-warning-info-elements-exist="yes"-->
+        <area aac="NSW_FA001" description="New South Wales" type="region">
+            <!--===================-->
+            <!--NON-HAZARD ELEMENTS-->
+            <!--===================-->
+            <!--locale[NSW_FA001]/period[variable]-->
+            <!--non-warning-info-elements-exist='yes'-->
+            <forecast-period start-time-local="2026-04-21T10:00:00+10:00" end-time-local="2026-04-25T00:00:00+10:00" start-time-utc="2026-04-21T00:00:00Z" end-time-utc="2026-04-24T14:00:00Z">
+                <warning-summary type="marine_forecast">Strong Wind Warning for Tuesday for Byron Coast and Coffs Coast</warning-summary>
+            </forecast-period>
+            <!--===============-->
+            <!--HAZARD ELEMENTS-->
+            <!--===============-->
+            <!--locale[NSW_FA001]/period[day0]-->
+            <forecast-period index="0" start-time-local="2026-04-21T10:00:00+10:00" end-time-local="2026-04-22T00:00:00+10:00" start-time-utc="2026-04-21T00:00:00Z" end-time-utc="2026-04-21T14:00:00Z">
+                <hazard index="1" parent-aac="NSW_FA001" phase="REN" type="MWW" severity="STR" urgency="UNK" certainty="UNK">
+                    <area-list>
+                        <area aac="NSW_MW008" phase="REN" description="Byron Coast: Point Danger to Wooli" type="coast"/>
+                        <area aac="NSW_MW007" phase="REN" description="Coffs Coast: Wooli to Smoky Cape" type="coast"/>
+                    </area-list>
+                    <priority>W</priority>
+                    <text type="warning_phenomena">Strong Wind Warning</text>
+                    <text type="warning_areas">Byron Coast and Coffs Coast</text>
+                </hazard>
+            </forecast-period>
+        </area>
+    </warning>
+</product>

--- a/tests/src/Functional/BomClientTest.php
+++ b/tests/src/Functional/BomClientTest.php
@@ -85,4 +85,38 @@ class BomClientTest extends TestCase {
     $meanSeaLevel = $pressure->getMeanSeaLevel();
   }
 
+  /**
+   * Tests the getWarning method.
+   */
+  public function testGetWarning(): void {
+    $logger = new NullLogger();
+    $httpClient = new Client();
+    $response = $this->createMock(ResponseInterface::class);
+    $response->method('getBody')
+      ->willReturn(new Stream(\fopen(__DIR__ . '/../../fixtures/IDN20400.xml', 'r')));
+    $httpClient->addResponse($response);
+    $requestFactory = $this->createMock(RequestFactoryInterface::class);
+    $request = $this->createMock(RequestInterface::class);
+    $requestFactory->method('createRequest')
+      ->willReturn($request);
+    $request->method('withHeader')->willReturn($request);
+    $client = new BomClient($httpClient, $requestFactory, $logger);
+    $warning = $client->getWarning('IDN20400');
+
+    $this->assertNotNull($warning);
+
+    // Check issue time.
+    $issueTime = $warning->getIssueTime();
+    $this->assertEquals('2026-04-21T00:00:00+00:00', $issueTime->format(\DATE_RFC3339));
+
+    // Check warning info.
+    $warningInfo = $warning->getWarningInfo();
+    $this->assertNotNull($warningInfo);
+    $this->assertEquals('Marine Wind Warning Summary for New South Wales', $warningInfo->getWarningTitle());
+
+    // Check regions.
+    $regions = $warning->getRegions();
+    $this->assertCount(1, $regions);
+  }
+
 }

--- a/tests/src/Unit/Warning/Serializer/WarningSerializerTest.php
+++ b/tests/src/Unit/Warning/Serializer/WarningSerializerTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace BomWeather\Tests\Unit\Warning\Serializer;
 
+use BomWeather\Warning\HazardCertainty;
+use BomWeather\Warning\HazardSeverity;
+use BomWeather\Warning\HazardUrgency;
 use BomWeather\Warning\Serializer\WarningSerializerFactory;
 use BomWeather\Warning\Warning;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -35,6 +38,7 @@ class WarningSerializerTest extends TestCase {
     $this->assertNotNull($warningInfo);
     $this->assertEquals('Marine Wind Warning Summary for New South Wales', $warningInfo->getWarningTitle());
     $this->assertEquals('The next marine wind warning summary will be issued by 4:05 pm EST Tuesday.', $warningInfo->getWarningNextIssue());
+    $this->assertStringContainsString('Check the latest Coastal Waters Forecast', $warningInfo->getPostamble());
 
     // Check regions.
     $regions = $warning->getRegions();
@@ -44,6 +48,32 @@ class WarningSerializerTest extends TestCase {
     $this->assertEquals('NSW_FA001', $region->getAac());
     $this->assertEquals('New South Wales', $region->getDescription());
     $this->assertEquals('region', $region->getType());
+
+    // Check hazards.
+    $hazards = $warning->getHazards();
+    $this->assertCount(1, $hazards);
+
+    $hazard = \array_shift($hazards);
+    $this->assertEquals('MWW', $hazard->getType());
+    $this->assertEquals(HazardSeverity::Strong, $hazard->getSeverity());
+    $this->assertEquals(HazardUrgency::Unknown, $hazard->getUrgency());
+    $this->assertEquals(HazardCertainty::Unknown, $hazard->getCertainty());
+    $this->assertEquals('W', $hazard->getPriority());
+    $this->assertEquals('Strong Wind Warning', $hazard->getPhenomena());
+    $this->assertEquals('Byron Coast and Coffs Coast', $hazard->getAreas());
+
+    // Check affected areas within hazard.
+    $affectedAreas = $hazard->getAffectedAreas();
+    $this->assertCount(2, $affectedAreas);
+
+    $firstArea = $affectedAreas[0];
+    $this->assertEquals('NSW_MW008', $firstArea->getAac());
+    $this->assertEquals('Byron Coast: Point Danger to Wooli', $firstArea->getDescription());
+    $this->assertEquals('coast', $firstArea->getType());
+
+    $secondArea = $affectedAreas[1];
+    $this->assertEquals('NSW_MW007', $secondArea->getAac());
+    $this->assertEquals('Coffs Coast: Wooli to Smoky Cape', $secondArea->getDescription());
   }
 
 }

--- a/tests/src/Unit/Warning/Serializer/WarningSerializerTest.php
+++ b/tests/src/Unit/Warning/Serializer/WarningSerializerTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BomWeather\Tests\Unit\Warning\Serializer;
+
+use BomWeather\Warning\Serializer\WarningSerializerFactory;
+use BomWeather\Warning\Warning;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the warning serializer.
+ */
+#[CoversClass(WarningSerializerFactory::class)]
+class WarningSerializerTest extends TestCase {
+
+  /**
+   * Tests deserialization of NSW marine warning data.
+   */
+  public function testDeserializeMarineWarning(): void {
+    $factory = new WarningSerializerFactory();
+    $serializer = $factory->create();
+
+    $xml = \file_get_contents(__DIR__ . '/../../../../fixtures/IDN20400.xml');
+
+    /** @var \BomWeather\Warning\Warning $warning */
+    $warning = $serializer->deserialize($xml, Warning::class, 'xml');
+
+    // Check issue time.
+    $this->assertEquals('2026-04-21T00:00:00+00:00', $warning->getIssueTime()->format(\DATE_RFC3339));
+
+    // Check warning info.
+    $warningInfo = $warning->getWarningInfo();
+    $this->assertNotNull($warningInfo);
+    $this->assertEquals('Marine Wind Warning Summary for New South Wales', $warningInfo->getWarningTitle());
+    $this->assertEquals('The next marine wind warning summary will be issued by 4:05 pm EST Tuesday.', $warningInfo->getWarningNextIssue());
+
+    // Check regions.
+    $regions = $warning->getRegions();
+    $this->assertCount(1, $regions);
+
+    $region = \array_shift($regions);
+    $this->assertEquals('NSW_FA001', $region->getAac());
+    $this->assertEquals('New South Wales', $region->getDescription());
+    $this->assertEquals('region', $region->getType());
+  }
+
+}


### PR DESCRIPTION
- Add `Warning`, `WarningInfo`, and `Hazard` value objects
- Add `HazardSeverity`, `HazardUrgency`, `HazardCertainty` enums
- Add `BomClient::getWarning()` method
- Add `fireDanger` property to `ForecastPeriod`
- Add `WeatherDataAccessorTrait` for safe data access
- Refactor normalizers to use `match` expressions
- Add tests and README documentation