### PR TITLE
Use PHPUnit TeamCity matcher instead of test reports

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,10 +6,6 @@ on:
   push:
     branches: [ main ]
 
-permissions:
-  checks: write
-  pull-requests: write
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -34,11 +30,14 @@ jobs:
         run: ./bin/phpcs --report=checkstyle -q | ./bin/cs2pr
       - name: 🧹 PHPStan
         run: ./bin/phpstan --error-format=github analyse
+      - name: ➕ Add PHPUnit matcher
+        run: |
+          cat << 'EOF' > .github/phpunit-failure.json
+          {"problemMatcher":[{"owner":"phpunit-failure","severity":"error","pattern":[{"regexp":"##teamcity\\[testFailed[^\\]]*message='([^']*)'[^\\]]*details='/data/([^:]+):(\\d+)","message":1,"file":2,"line":3}]}]}
+          EOF
+          echo "::add-matcher::.github/phpunit-failure.json"
       - name: ⚡ Run Tests
-        run: ./bin/phpunit --log-junit phpunit-results.xml
-      - name: 📝 Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        run: ./bin/phpunit --teamcity
+      - name: ➖ Remove PHPUnit matcher
         if: always()
-        with:
-          files: phpunit-results.xml
-          check_name: Test Results ${{ matrix.php }} ${{ matrix.prefer_lowest }}
+        run: echo "::remove-matcher owner=phpunit-failure::"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         --user 1001:1001
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           show-progress: false
       - name: 📦 Composer Update


### PR DESCRIPTION
## Summary
- Replace `EnricoMi/publish-unit-test-result-action` with PHPUnit TeamCity output and a problem matcher
- Remove unnecessary `permissions` block (was only needed for test reports action)
- PHPUnit failures now generate inline GitHub annotations via the matcher

PHPCS and PHPStan already output in formats that generate GitHub annotations.